### PR TITLE
Implemented GTFS-RT Feed for OTP Updaters

### DIFF
--- a/GTFS-RT-FEED/.env.example
+++ b/GTFS-RT-FEED/.env.example
@@ -1,0 +1,10 @@
+# Redis Configuration
+REDIS_HOST=your-redis-server.example.com
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_KEY=gtfs_realtime_data:tripupdates
+REDIS_PASSWORD=your-strong-password
+
+# Application Configuration
+APP_PORT=8004
+DEV_MODE=false  # Set to true for development with hot reloading 

--- a/GTFS-RT-FEED/.gitignore
+++ b/GTFS-RT-FEED/.gitignore
@@ -1,0 +1,2 @@
+.env
+app.log

--- a/GTFS-RT-FEED/Dockerfile
+++ b/GTFS-RT-FEED/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+COPY .env* ./ 
+
+EXPOSE 8004
+
+CMD ["sh", "-c", "if [ \"$DEV_MODE\" = \"true\" ]; then uvicorn main:app --host 0.0.0.0 --port 8004 --reload; else uvicorn main:app --host 0.0.0.0 --port 8004; fi"] 

--- a/GTFS-RT-FEED/README.md
+++ b/GTFS-RT-FEED/README.md
@@ -1,0 +1,142 @@
+# GTFS Realtime Feed API
+
+A FastAPI application that serves GTFS realtime data from Redis.
+
+## API Endpoints
+
+The API follows a structured approach to provide access to different types of GTFS Realtime data:
+
+### Main Endpoints
+
+- **API Root**: `/` - Information about all available endpoints
+- **Trip Updates**: `/gtfs-rt/trip-updates` - Information about trip updates endpoints
+  - **Protobuf format**: `/gtfs-rt/trip-updates/pb`
+  - **JSON format**: `/gtfs-rt/trip-updates/json`
+- **Original Trip Updates Endpoints**:
+  - **Protobuf format**: `/tripupdates.pb`
+  - **JSON format**: `/tripupdates.json`
+- **Vehicle Positions**: `/gtfs-rt/vehicle-positions` - Coming soon
+- **Service Alerts**: `/gtfs-rt/service-alerts` - Coming soon
+
+### Legacy Endpoints (Deprecated)
+
+These endpoints are maintained for backward compatibility but will be removed in future versions:
+
+- **Protobuf format**: `/tripupdates.pb`
+- **JSON format**: `/tripupdates.json`
+
+## Setup
+
+### Using Docker Compose
+
+1. Create a `.env` file in the project root with the following variables:
+
+```bash
+# Redis Configuration
+REDIS_HOST=host.docker.internal
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_KEY=gtfs_realtime_data:tripupdates
+# REDIS_PASSWORD=your_password_here  # Uncomment and set if Redis requires authentication
+
+# Application Configuration
+APP_PORT=8004
+DEV_MODE=true  # Set to true for hot reloading # Set to false in production
+```
+
+2. Start the services:
+```bash
+docker compose up -d
+```
+
+3. To stop the services:
+```bash
+docker compose down
+```
+
+4. To view logs:
+```bash
+docker compose logs -f
+```
+
+## Configuration
+
+The following environment variables can be set:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| REDIS_HOST | Redis host | host.docker.internal |
+| REDIS_PORT | Redis port | 6379 |
+| REDIS_DB | Redis database number | 0 |
+| REDIS_KEY | Redis key for trip updates | gtfs_realtime_data:tripupdates |
+| REDIS_PASSWORD | Redis password | None |
+| APP_PORT | Application port | 8004 |
+
+These can be set in `.env` file for development or as environment variables in Docker.
+
+## Redis Data Format
+
+The application expects trip update data to be stored in Redis under the key specified by `REDIS_KEY` (default: `gtfs_realtime_data:tripupdates`). The data should be a JSON object with the following structure:
+
+```json
+{
+  "header": {
+    "gtfsRealtimeVersion": "2.0",
+    "incrementality": "FULL_DATASET",
+    "timestamp": "1745591074"
+  },
+  "entity": [
+    {
+      "id": "1",
+      "tripUpdate": {
+        "trip": {
+          "tripId": "4796-S-UP-53717",
+          "startTime": "05:40:00",
+          "startDate": "20250611",
+          "routeId": "4796",
+          "directionId": 0
+        },
+        "stopTimeUpdate": [
+          {
+            "stopSequence": 2,
+            "arrival": {
+              "time": "1749600920"
+            },
+            "departure": {
+              "time": "1749605700"
+            },
+            "stopId": "KwaxxmSs"
+          }
+        ],
+        "vehicle": {
+          "id": "vehicle_4796",
+          "label": "PB07"
+        },
+        "timestamp": "1745591074"
+      }
+    }
+  ]
+}
+```
+
+### Setting up Test Data in Redis (For testing locally)
+
+1. Access Redis CLI:
+```bash
+docker compose exec redis redis-cli
+```
+
+2. Set test data:
+```bash
+JSON.SET gtfs_realtime_data:tripupdates $ '{"header":{"gtfsRealtimeVersion":"2.0","incrementality":"FULL_DATASET","timestamp":"1745591074"},"entity":[{"id":"1","tripUpdate":{"trip":{"tripId":"4796-S-UP-53717","startTime":"05:40:00","startDate":"20250611","routeId":"4796","directionId":0},"stopTimeUpdate":[{"stopSequence":2,"arrival":{"time":"1749600920"},"departure":{"time":"1749605700"},"stopId":"KwaxxmSs"}],"vehicle":{"id":"vehicle_4796","label":"PB07"},"timestamp":"1745591074"}}]}'
+```
+
+3. Check the data in Redis GUI:
+```bash
+http://localhost:8001/redis-stack/browser
+```
+
+3. Test the API:
+```bash
+curl http://localhost:8004/gtfs-rt/trip-updates/json
+```

--- a/GTFS-RT-FEED/docker-compose.yml
+++ b/GTFS-RT-FEED/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  gtfs-rt-feed:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8004:8004"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      - DEV_MODE=true 

--- a/GTFS-RT-FEED/main.py
+++ b/GTFS-RT-FEED/main.py
@@ -1,0 +1,204 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from datetime import datetime
+import time
+import redis
+from google.transit import gtfs_realtime_pb2
+from google.protobuf import json_format
+import json
+import os
+import logging
+from logging.handlers import RotatingFileHandler
+import uvicorn
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        RotatingFileHandler('app.log', maxBytes=10485760, backupCount=5),  # 10MB per file, keep 5 backups
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="GTFS Realtime Feed API", 
+              description="A FastAPI service that serves GTFS realtime data from Redis",
+              version="1.0.0")
+
+REDIS_HOST = os.getenv("REDIS_HOST", "host.docker.internal")
+REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
+REDIS_DB = int(os.getenv("REDIS_DB", 0))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", None)
+APP_PORT = int(os.getenv("APP_PORT", 8004))
+REDIS_KEY = os.getenv("REDIS_KEY", "gtfs_realtime_data:tripupdates")\
+
+DEV_MODE = os.getenv("DEV_MODE", "false").lower() == "true"
+
+logger.info(f"Connecting to Redis at {REDIS_HOST}:{REDIS_PORT} (DB: {REDIS_DB})")
+
+try:
+    redis_client = redis.Redis(
+        host=REDIS_HOST,
+        port=REDIS_PORT,
+        db=REDIS_DB,
+        password=REDIS_PASSWORD or None,
+        socket_timeout=5,
+        socket_connect_timeout=5,
+        retry_on_timeout=True,
+        health_check_interval=30,
+        decode_responses=False
+    )
+    redis_client.ping()
+    logger.info("Successfully connected to Redis")
+except redis.ConnectionError as e:
+    logger.error(f"Failed to connect to Redis: {str(e)}")
+    raise
+except Exception as e:
+    logger.error(f"Unexpected error connecting to Redis: {str(e)}")
+    raise
+
+def get_trip_updates_from_redis():
+    try:
+        logger.info(f"Fetching trip updates from Redis key: {REDIS_KEY}")
+        trip_updates = redis_client.json().get(REDIS_KEY)
+        if not trip_updates:
+            logger.warning(f"No trip updates found in Redis key {REDIS_KEY}")
+            raise HTTPException(status_code=404, detail=f"No trip updates found in Redis")
+        
+        logger.debug(f"Retrieved trip data: {trip_updates}")
+        
+        feed = gtfs_realtime_pb2.FeedMessage()
+        
+        header_timestamp = trip_updates.get('header', {}).get('timestamp')
+        if isinstance(header_timestamp, str):
+            header_timestamp = int(header_timestamp)
+        
+        feed.header.gtfs_realtime_version = trip_updates.get('header', {}).get('gtfsRealtimeVersion', '2.0')
+        feed.header.incrementality = gtfs_realtime_pb2.FeedHeader.FULL_DATASET
+        feed.header.timestamp = header_timestamp or int(time.time())
+        
+        for entity_data in trip_updates.get('entity', []):
+            entity = feed.entity.add()
+            entity.id = entity_data.get('id', '1')
+            
+            if 'tripUpdate' in entity_data:
+                trip_update_data = entity_data['tripUpdate']
+                
+                if 'trip' in trip_update_data:
+                    trip_data = trip_update_data['trip']
+                    entity.trip_update.trip.trip_id = trip_data.get('tripId', '')
+                    entity.trip_update.trip.start_time = trip_data.get('startTime', '')
+                    entity.trip_update.trip.start_date = trip_data.get('startDate', '')
+                    entity.trip_update.trip.route_id = trip_data.get('routeId', '')
+                    entity.trip_update.trip.direction_id = trip_data.get('directionId', 0)
+                
+                if 'vehicle' in trip_update_data:
+                    vehicle_data = trip_update_data['vehicle']
+                    entity.trip_update.vehicle.id = vehicle_data.get('id', '')
+                    entity.trip_update.vehicle.label = vehicle_data.get('label', '')
+                
+                for stop_time_update in trip_update_data.get('stopTimeUpdate', []):
+                    update = entity.trip_update.stop_time_update.add()
+                    update.stop_sequence = stop_time_update.get('stopSequence', 0)
+                    update.stop_id = stop_time_update.get('stopId', '')
+                    
+                    if 'arrival' in stop_time_update:
+                        arrival_time = stop_time_update['arrival'].get('time', 0)
+                        if isinstance(arrival_time, str):
+                            arrival_time = int(arrival_time)
+                        update.arrival.time = arrival_time
+                    
+                    if 'departure' in stop_time_update:
+                        departure_time = stop_time_update['departure'].get('time', 0)
+                        if isinstance(departure_time, str):
+                            departure_time = int(departure_time)
+                        update.departure.time = departure_time
+                
+                timestamp = trip_update_data.get('timestamp')
+                if isinstance(timestamp, str):
+                    timestamp = int(timestamp)
+                entity.trip_update.timestamp = timestamp or int(time.time())
+        
+        logger.info(f"Successfully generated feed with {len(feed.entity)} entities")
+        return feed
+        
+    except redis.RedisError as e:
+        logger.error(f"Redis error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Redis error: {str(e)}")
+    except Exception as e:
+        logger.error(f"Error processing trip updates: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Error processing trip updates: {str(e)}")
+
+
+@app.get("/")
+async def root():
+    """API root with information about available endpoints"""
+    return {
+        "api": "GTFS Realtime Feed API",
+        "version": "1.0.0",
+        "endpoints": {
+            "trip_updates": "/gtfs-rt/trip-updates",
+            "vehicle_positions": "/gtfs-rt/vehicle-positions (coming soon)",
+            "service_alerts": "/gtfs-rt/service-alerts (coming soon)"
+        }
+    }
+
+
+@app.get("/gtfs-rt/trip-updates", tags=["Trip Updates"])
+async def trip_updates_info():
+    """Information about trip updates endpoints"""
+    return {
+        "description": "GTFS-RT Trip Updates feed",
+        "formats": {
+            "protobuf": "/gtfs-rt/trip-updates/pb",
+            "json": "/gtfs-rt/trip-updates/json"
+        }
+    }
+
+@app.get("/gtfs-rt/trip-updates/pb", tags=["Trip Updates"])
+async def get_trip_updates_protobuf():
+    """Get trip updates in protobuf format"""
+    logger.info("Received request for protobuf trip updates")
+    feed = get_trip_updates_from_redis()
+    return Response(
+        content=feed.SerializeToString(),
+        media_type="application/x-protobuf"
+    )
+
+@app.get("/gtfs-rt/trip-updates/json", tags=["Trip Updates"])
+async def get_trip_updates_json():
+    """Get trip updates in JSON format"""
+    logger.info("Received request for JSON trip updates")
+    feed = get_trip_updates_from_redis()
+    return json_format.MessageToDict(feed)
+
+# Placeholder endpoints for future implementation
+@app.get("/gtfs-rt/vehicle-positions", tags=["Coming Soon"])
+async def vehicle_positions_info():
+    """Information about vehicle positions endpoints (coming soon)"""
+    return {
+        "status": "Not implemented yet",
+        "description": "GTFS-RT Vehicle Positions feed",
+        "coming_soon": True
+    }
+
+@app.get("/gtfs-rt/service-alerts", tags=["Coming Soon"])
+async def service_alerts_info():
+    """Information about service alerts endpoints (coming soon)"""
+    return {
+        "status": "Not implemented yet",
+        "description": "GTFS-RT Service Alerts feed",
+        "coming_soon": True
+    }
+
+@app.on_event("startup")
+async def startup_event():
+    logger.info("Application startup complete")
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    logger.info("Application shutdown initiated")
+
+if __name__ == "__main__":
+    logger.info(f"Starting application on port {APP_PORT}")
+    uvicorn.run(app, host="0.0.0.0", port=APP_PORT) 

--- a/GTFS-RT-FEED/requirements.txt
+++ b/GTFS-RT-FEED/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.109.2
+uvicorn==0.27.1
+redis==5.0.1
+gtfs-realtime-bindings==1.0.0
+protobuf==4.25.3
+python-dotenv==1.0.1 


### PR DESCRIPTION
# FastAPI Application for Serving GTFS Realtime Data from Redis

## Overview
This FastAPI application serves **GTFS Realtime (GTFS-RT)** data retrieved from **Redis**.

## Usage

- **Data Source:**  
  The application fetches GTFS-RT data from a Redis instance.

- **Serving Endpoint:**  
  Updaters configured in the `router-config.json` of **OpenTripPlanner (OTP)** should fetch data from the following endpoint:

  ```bash
  /gtfs-rt/trip-updates/pb
  ```

## Notes

- Ensure that `router-config.json` in OTP points to the correct endpoint (`/gtfs-rt/trip-updates/pb`) to fetch realtime trip updates.
- Redis must be populated with up-to-date GTFS-RT data for the application to serve meaningful responses.
