### PR TITLE
added IST timezone

### DIFF
--- a/GTFS-RT-FEED/CRONs/poll_train_tripupdates.py
+++ b/GTFS-RT-FEED/CRONs/poll_train_tripupdates.py
@@ -7,6 +7,9 @@ from datetime import datetime
 import logging
 from dotenv import load_dotenv
 from pathlib import Path
+import pytz
+
+ist = pytz.timezone("Asia/Kolkata")
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 log_file = SCRIPT_DIR / 'train_updates.log'
@@ -119,9 +122,13 @@ def transform_to_gtfs_rt(data):
             
             sched_arrival = datetime.combine(train_start_date.date(), sched_arrival_time)
             sched_departure = datetime.combine(train_start_date.date(), sched_departure_time)
+
+            sched_arrival_ist = ist.localize(sched_arrival)
+            sched_departure_ist = ist.localize(sched_departure)
             
-            actual_arrival = sched_arrival.timestamp() + station['delayArrival']
-            actual_departure = sched_departure.timestamp() + station['delayDeparture']
+            actual_arrival = sched_arrival_ist.timestamp() + station['delayArrival']
+            actual_departure = sched_departure_ist.timestamp() + station['delayDeparture']
+            
 
             stop_update = {
                 "stopSequence": station['sequence'],

--- a/GTFS-RT-FEED/requirements.txt
+++ b/GTFS-RT-FEED/requirements.txt
@@ -11,6 +11,7 @@ protobuf==4.25.3
 pydantic==2.11.4
 pydantic_core==2.33.2
 python-dotenv==1.0.1
+pytz==2025.2
 redis==5.0.1
 requests==2.32.3
 setuptools==80.3.1


### PR DESCRIPTION
Earlier we did not consider timezone for train updates in the code. Since the train updates API response is in IST, the code assumed it to be UTC by default. Added IST timezone for proper conversion of data from railways API to GTFS-RT format.